### PR TITLE
Fix Antora metadata for consistency

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: quarkus-hibernate-search-extras
-title: Quarkus - Hibernate Search Extras
+title: Quarkus Hibernate Search Extras
 version: dev
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
The idea is that it's not a part from Quarkus so we avoid the dash.