### PR TITLE
Update code to use packages from the latest Quarkus snapshots

### DIFF
--- a/hibernate-search-orm-elasticsearch-aws/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/aws/HibernateSearchOrmElasticsearchAwsProcessor.java
+++ b/hibernate-search-orm-elasticsearch-aws/deployment/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/aws/HibernateSearchOrmElasticsearchAwsProcessor.java
@@ -6,10 +6,10 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
-import io.quarkus.hibernate.search.orm.elasticsearch.HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem;
-import io.quarkus.hibernate.search.orm.elasticsearch.HibernateSearchIntegrationRuntimeConfiguredBuildItem;
 import io.quarkus.hibernate.search.orm.elasticsearch.aws.runtime.HibernateSearchOrmElasticsearchAwsRecorder;
 import io.quarkus.hibernate.search.orm.elasticsearch.aws.runtime.HibernateSearchOrmElasticsearchAwsRuntimeConfig;
+import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchElasticsearchPersistenceUnitConfiguredBuildItem;
+import io.quarkus.hibernate.search.orm.elasticsearch.deployment.HibernateSearchIntegrationRuntimeConfiguredBuildItem;
 
 class HibernateSearchOrmElasticsearchAwsProcessor {
 


### PR DESCRIPTION
See https://github.com/quarkusio/quarkus/pull/26147

The build against Quarkus 2.10 is expected to fail. It will work with the latest snapshot, though.