### PR TITLE
Use the correct GAV for the AWS BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>io.quarkus.platform</groupId>
+                <groupId>io.quarkiverse.amazonservices</groupId>
                 <artifactId>quarkus-amazon-services-bom</artifactId>
-                <version>${quarkus.version}</version>
+                <version>${quarkus-amazon-services.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -141,6 +141,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus-staging-maven-plugin.version}</version>
                 <extensions>false</extensions><!-- This is essential: do not put true here -->
                 <executions>
                     <execution>


### PR DESCRIPTION
So that the Quarkiverse CI Build doesn't switch to version 999-SNAPSHOT of the BOM when it updates `quarkus.version`.