### PR TITLE
Use quarkus-extension-maven-plugin instead of quarkus-bootstrap-maven-plugin

### DIFF
--- a/hibernate-search-orm-elasticsearch-aws/runtime/pom.xml
+++ b/hibernate-search-orm-elasticsearch-aws/runtime/pom.xml
@@ -88,7 +88,7 @@
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
                 </plugin>
                 <plugin>
                     <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                    <artifactId>quarkus-extension-maven-plugin</artifactId>
                     <version>${quarkus.version}</version>
                     <executions>
                         <execution>


### PR DESCRIPTION
quarkus-bootstrap-maven-plugin is being removed in Quarkus 3.

Fixes https://github.com/quarkiverse/quarkiverse/issues/57#issuecomment-1489720825