### PR TITLE
Upgrade to quarkus-amazon-services 2.4.2 and migrate to @ConfigMapping

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.2.0.Final
+:quarkus-version: 3.2.2.Final
 :quarkus-hibernate-search-extras-version: 2.0.3
 
 :quarkus-org-url: https://github.com/quarkusio

--- a/docs/modules/ROOT/pages/includes/quarkus-hibernate-search-orm-elasticsearch-aws.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-hibernate-search-orm-elasticsearch-aws.adoc
@@ -10,23 +10,23 @@ h|[[quarkus-hibernate-search-orm-elasticsearch-aws_configuration]]link:#quarkus-
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled[quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.signing.enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.signing.enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.signing.enabled]`
 
 [.description]
 --
 Whether requests should be signed using the AWS credentials.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_SIGNING_ENABLED+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_SIGNING_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_SIGNING_ENABLED+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_SIGNING_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`false`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.region]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.region[quarkus.hibernate-search-orm.elasticsearch.aws.region]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.region]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.region[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.region]`
 
 [.description]
 --
@@ -37,16 +37,16 @@ Must be provided if signing is enabled; the region won't be automatically detect
 See `software.amazon.awssdk.regions.Region` for available regions.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_REGION+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_REGION+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_REGION+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_REGION+++`
 endif::add-copy-button-to-env-var[]
 --|Region 
 |
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.type]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.type[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.type]`
 
 [.description]
 --
@@ -76,250 +76,22 @@ Available values:
                 fail unless the resource or API's policy has been configured to specifically allow anonymous access.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_TYPE+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_TYPE+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_TYPE+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_TYPE+++`
 endif::add-copy-button-to-env-var[]
 -- a|
 `default`, `static`, `system-property`, `env-variable`, `profile`, `container`, `instance-profile`, `process`, `custom`, `anonymous` 
 |`default`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.signing.enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.signing.enabled[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.signing.enabled]`
-
-[.description]
---
-Whether requests should be signed using the AWS credentials.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_SIGNING_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_SIGNING_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.region]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.region[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.region]`
-
-[.description]
---
-An Amazon Web Services region that hosts the Elasticsearch service.
-
-Must be provided if signing is enabled; the region won't be automatically detected.
-
-See `software.amazon.awssdk.regions.Region` for available regions.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_REGION+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_REGION+++`
-endif::add-copy-button-to-env-var[]
---|Region 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.type]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.type[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.type]`
-
-[.description]
---
-Configure the credentials provider that should be used to authenticate with AWS.
-
-Available values:
-
-* `default` - the provider will attempt to identify the credentials automatically using the following checks:
-** Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`
-** Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-** Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
-** Credentials delivered through the Amazon EC2 container service if `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and security manager has permission to access the variable.
-** Instance profile credentials delivered through the Amazon EC2 metadata service
-* `static` - the provider that uses the access key and secret access key specified in the `static-provider` section of the config.
-* `system-property` - it loads credentials from the `aws.accessKeyId`, `aws.secretAccessKey` and `aws.sessionToken` system properties.
-* `env-variable` - it loads credentials from the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` environment variables.
-* `profile` - credentials are based on AWS configuration profiles. This loads credentials from
-              a http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[profile file],
-              allowing you to share multiple sets of AWS security credentials between different tools like the AWS SDK for Java and the AWS CLI.
-* `container` - It loads credentials from a local metadata service. Containers currently supported by the AWS SDK are
-                **Amazon Elastic Container Service (ECS)** and **AWS Greengrass**
-* `instance-profile` - It loads credentials from the Amazon EC2 Instance Metadata Service.
-* `process` - Credentials are loaded from an external process. This is used to support the credential_process setting in the profile
-              credentials file. See https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes[Sourcing Credentials From External Processes]
-              for more information.
-* `anonymous` - It always returns anonymous AWS credentials. Anonymous AWS credentials result in un-authenticated requests and will
-                fail unless the resource or API's policy has been configured to specifically allow anonymous access.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_TYPE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_TYPE+++`
-endif::add-copy-button-to-env-var[]
--- a|
-`default`, `static`, `system-property`, `env-variable`, `profile`, `container`, `instance-profile`, `process`, `custom`, `anonymous` 
-|`default`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.signing.enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.signing.enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.signing.enabled]`
-
-[.description]
---
-Whether requests should be signed using the AWS credentials.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_SIGNING_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_SIGNING_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.region]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.region[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.region]`
-
-[.description]
---
-An Amazon Web Services region that hosts the Elasticsearch service.
-
-Must be provided if signing is enabled; the region won't be automatically detected.
-
-See `software.amazon.awssdk.regions.Region` for available regions.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_REGION+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_REGION+++`
-endif::add-copy-button-to-env-var[]
---|Region 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.type]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.type[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.type]`
-
-[.description]
---
-Configure the credentials provider that should be used to authenticate with AWS.
-
-Available values:
-
-* `default` - the provider will attempt to identify the credentials automatically using the following checks:
-** Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`
-** Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-** Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
-** Credentials delivered through the Amazon EC2 container service if `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and security manager has permission to access the variable.
-** Instance profile credentials delivered through the Amazon EC2 metadata service
-* `static` - the provider that uses the access key and secret access key specified in the `static-provider` section of the config.
-* `system-property` - it loads credentials from the `aws.accessKeyId`, `aws.secretAccessKey` and `aws.sessionToken` system properties.
-* `env-variable` - it loads credentials from the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` environment variables.
-* `profile` - credentials are based on AWS configuration profiles. This loads credentials from
-              a http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[profile file],
-              allowing you to share multiple sets of AWS security credentials between different tools like the AWS SDK for Java and the AWS CLI.
-* `container` - It loads credentials from a local metadata service. Containers currently supported by the AWS SDK are
-                **Amazon Elastic Container Service (ECS)** and **AWS Greengrass**
-* `instance-profile` - It loads credentials from the Amazon EC2 Instance Metadata Service.
-* `process` - Credentials are loaded from an external process. This is used to support the credential_process setting in the profile
-              credentials file. See https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes[Sourcing Credentials From External Processes]
-              for more information.
-* `anonymous` - It always returns anonymous AWS credentials. Anonymous AWS credentials result in un-authenticated requests and will
-                fail unless the resource or API's policy has been configured to specifically allow anonymous access.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_TYPE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_TYPE+++`
-endif::add-copy-button-to-env-var[]
--- a|
-`default`, `static`, `system-property`, `env-variable`, `profile`, `container`, `instance-profile`, `process`, `custom`, `anonymous` 
-|`default`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.signing.enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.signing.enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.signing.enabled]`
-
-[.description]
---
-Whether requests should be signed using the AWS credentials.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_SIGNING_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_SIGNING_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.region]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.region[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.region]`
-
-[.description]
---
-An Amazon Web Services region that hosts the Elasticsearch service.
-
-Must be provided if signing is enabled; the region won't be automatically detected.
-
-See `software.amazon.awssdk.regions.Region` for available regions.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_REGION+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_REGION+++`
-endif::add-copy-button-to-env-var[]
---|Region 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.type]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.type[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.type]`
-
-[.description]
---
-Configure the credentials provider that should be used to authenticate with AWS.
-
-Available values:
-
-* `default` - the provider will attempt to identify the credentials automatically using the following checks:
-** Java System Properties - `aws.accessKeyId` and `aws.secretAccessKey`
-** Environment Variables - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-** Credential profiles file at the default location (`~/.aws/credentials`) shared by all AWS SDKs and the AWS CLI
-** Credentials delivered through the Amazon EC2 container service if `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set and security manager has permission to access the variable.
-** Instance profile credentials delivered through the Amazon EC2 metadata service
-* `static` - the provider that uses the access key and secret access key specified in the `static-provider` section of the config.
-* `system-property` - it loads credentials from the `aws.accessKeyId`, `aws.secretAccessKey` and `aws.sessionToken` system properties.
-* `env-variable` - it loads credentials from the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` environment variables.
-* `profile` - credentials are based on AWS configuration profiles. This loads credentials from
-              a http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html[profile file],
-              allowing you to share multiple sets of AWS security credentials between different tools like the AWS SDK for Java and the AWS CLI.
-* `container` - It loads credentials from a local metadata service. Containers currently supported by the AWS SDK are
-                **Amazon Elastic Container Service (ECS)** and **AWS Greengrass**
-* `instance-profile` - It loads credentials from the Amazon EC2 Instance Metadata Service.
-* `process` - Credentials are loaded from an external process. This is used to support the credential_process setting in the profile
-              credentials file. See https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes[Sourcing Credentials From External Processes]
-              for more information.
-* `anonymous` - It always returns anonymous AWS credentials. Anonymous AWS credentials result in un-authenticated requests and will
-                fail unless the resource or API's policy has been configured to specifically allow anonymous access.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_TYPE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_TYPE+++`
-endif::add-copy-button-to-env-var[]
--- a|
-`default`, `static`, `system-property`, `env-variable`, `profile`, `container`, `instance-profile`, `process`, `custom`, `anonymous` 
-|`default`
-
-
-h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider-default-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider-default-credentials-provider-configuration[Default credentials provider configuration]
+h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.default-provider-default-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.default-provider-default-credentials-provider-configuration[Default credentials provider configuration]
 
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.default-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.default-provider.async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.default-provider.async-credential-update-enabled]`
 
 [.description]
 --
@@ -328,16 +100,16 @@ Whether this provider should fetch credentials asynchronously in the background.
 If this is `true`, threads are less likely to block, but additional resources are used to maintain the provider.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_DEFAULT_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_DEFAULT_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`false`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.default-provider.reuse-last-provider-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.default-provider.reuse-last-provider-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.default-provider.reuse-last-provider-enabled]`
 
 [.description]
 --
@@ -346,326 +118,74 @@ Whether the provider should reuse the last successful credentials provider in th
 Reusing the last successful credentials provider will typically return credentials faster than searching through the chain.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_DEFAULT_PROVIDER_REUSE_LAST_PROVIDER_ENABLED+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_REUSE_LAST_PROVIDER_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_DEFAULT_PROVIDER_REUSE_LAST_PROVIDER_ENABLED+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_REUSE_LAST_PROVIDER_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.default-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.default-provider.async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.default-provider.async-credential-update-enabled]`
-
-[.description]
---
-Whether this provider should fetch credentials asynchronously in the background.
-
-If this is `true`, threads are less likely to block, but additional resources are used to maintain the provider.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.default-provider.reuse-last-provider-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.default-provider.reuse-last-provider-enabled[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.default-provider.reuse-last-provider-enabled]`
-
-[.description]
---
-Whether the provider should reuse the last successful credentials provider in the chain.
-
-Reusing the last successful credentials provider will typically return credentials faster than searching through the chain.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_REUSE_LAST_PROVIDER_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_REUSE_LAST_PROVIDER_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`true`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.default-provider.async-credential-update-enabled]`
-
-[.description]
---
-Whether this provider should fetch credentials asynchronously in the background.
-
-If this is `true`, threads are less likely to block, but additional resources are used to maintain the provider.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_DEFAULT_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_DEFAULT_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled]`
-
-[.description]
---
-Whether the provider should reuse the last successful credentials provider in the chain.
-
-Reusing the last successful credentials provider will typically return credentials faster than searching through the chain.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_DEFAULT_PROVIDER_REUSE_LAST_PROVIDER_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_DEFAULT_PROVIDER_REUSE_LAST_PROVIDER_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`true`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.default-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.default-provider.async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.default-provider.async-credential-update-enabled]`
-
-[.description]
---
-Whether this provider should fetch credentials asynchronously in the background.
-
-If this is `true`, threads are less likely to block, but additional resources are used to maintain the provider.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.default-provider.reuse-last-provider-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.default-provider.reuse-last-provider-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.default-provider.reuse-last-provider-enabled]`
-
-[.description]
---
-Whether the provider should reuse the last successful credentials provider in the chain.
-
-Reusing the last successful credentials provider will typically return credentials faster than searching through the chain.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_REUSE_LAST_PROVIDER_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_DEFAULT_PROVIDER_REUSE_LAST_PROVIDER_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`true`
-
-
-h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider-static-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider-static-credentials-provider-configuration[Static credentials provider configuration]
+h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.static-provider-static-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.static-provider-static-credentials-provider-configuration[Static credentials provider configuration]
 
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.static-provider.access-key-id]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.static-provider.access-key-id[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.static-provider.access-key-id]`
 
 [.description]
 --
 AWS Access key id
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.static-provider.secret-access-key]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.static-provider.secret-access-key[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.static-provider.secret-access-key]`
 
 [.description]
 --
 AWS Secret access key
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.session-token]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.session-token[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.session-token]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.static-provider.session-token]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.static-provider.session-token[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.static-provider.session-token]`
 
 [.description]
 --
 AWS Session token
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_SESSION_TOKEN+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SESSION_TOKEN+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_SESSION_TOKEN+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SESSION_TOKEN+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.access-key-id]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.access-key-id[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.static-provider.access-key-id]`
-
-[.description]
---
-AWS Access key id
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.secret-access-key]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.secret-access-key[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.static-provider.secret-access-key]`
-
-[.description]
---
-AWS Secret access key
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.session-token]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.session-token[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.static-provider.session-token]`
-
-[.description]
---
-AWS Session token
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SESSION_TOKEN+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SESSION_TOKEN+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.static-provider.access-key-id]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.static-provider.access-key-id[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.static-provider.access-key-id]`
-
-[.description]
---
-AWS Access key id
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.static-provider.secret-access-key]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.static-provider.secret-access-key[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.static-provider.secret-access-key]`
-
-[.description]
---
-AWS Secret access key
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.static-provider.session-token]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.static-provider.session-token[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.static-provider.session-token]`
-
-[.description]
---
-AWS Session token
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_SESSION_TOKEN+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_STATIC_PROVIDER_SESSION_TOKEN+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.access-key-id]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.access-key-id[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.static-provider.access-key-id]`
-
-[.description]
---
-AWS Access key id
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.secret-access-key]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.secret-access-key[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.static-provider.secret-access-key]`
-
-[.description]
---
-AWS Secret access key
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.session-token]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.static-provider.session-token[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.static-provider.session-token]`
-
-[.description]
---
-AWS Session token
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SESSION_TOKEN+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_STATIC_PROVIDER_SESSION_TOKEN+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider-aws-profile-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider-aws-profile-credentials-provider-configuration[AWS Profile credentials provider configuration]
+h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.profile-provider-aws-profile-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.profile-provider-aws-profile-credentials-provider-configuration[AWS Profile credentials provider configuration]
 
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider.profile-name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider.profile-name[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider.profile-name]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.profile-provider.profile-name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.profile-provider.profile-name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.profile-provider.profile-name]`
 
 [.description]
 --
@@ -674,75 +194,21 @@ The name of the profile that should be used by this credentials provider.
 If not specified, the value in `AWS_PROFILE` environment variable or `aws.profile` system property is used and defaults to `default` name.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROFILE_PROVIDER_PROFILE_NAME+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_PROFILE_PROVIDER_PROFILE_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROFILE_PROVIDER_PROFILE_NAME+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_PROFILE_PROVIDER_PROFILE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.profile-provider.profile-name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.profile-provider.profile-name[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.profile-provider.profile-name]`
-
-[.description]
---
-The name of the profile that should be used by this credentials provider.
-
-If not specified, the value in `AWS_PROFILE` environment variable or `aws.profile` system property is used and defaults to `default` name.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROFILE_PROVIDER_PROFILE_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROFILE_PROVIDER_PROFILE_NAME+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.profile-provider.profile-name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.profile-provider.profile-name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.profile-provider.profile-name]`
-
-[.description]
---
-The name of the profile that should be used by this credentials provider.
-
-If not specified, the value in `AWS_PROFILE` environment variable or `aws.profile` system property is used and defaults to `default` name.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_PROFILE_PROVIDER_PROFILE_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_PROFILE_PROVIDER_PROFILE_NAME+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.profile-provider.profile-name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.profile-provider.profile-name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.profile-provider.profile-name]`
-
-[.description]
---
-The name of the profile that should be used by this credentials provider.
-
-If not specified, the value in `AWS_PROFILE` environment variable or `aws.profile` system property is used and defaults to `default` name.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROFILE_PROVIDER_PROFILE_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROFILE_PROVIDER_PROFILE_NAME+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider-process-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider-process-credentials-provider-configuration[Process credentials provider configuration]
+h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.process-provider-process-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.process-provider-process-credentials-provider-configuration[Process credentials provider configuration]
 
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.process-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.process-provider.async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.async-credential-update-enabled]`
 
 [.description]
 --
@@ -751,16 +217,16 @@ Whether the provider should fetch credentials asynchronously in the background.
 If this is true, threads are less likely to block when credentials are loaded, but additional resources are used to maintain the provider.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`false`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.process-provider.credential-refresh-threshold]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.process-provider.credential-refresh-threshold[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.credential-refresh-threshold]`
 
 [.description]
 --
@@ -769,319 +235,64 @@ The amount of time between when the credentials expire and when the credentials 
 This allows the credentials to be refreshed ++*++before++*++ they are reported to expire.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
   link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
 |`15S`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.process-output-limit]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.process-output-limit[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.process-output-limit]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.process-provider.process-output-limit]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.process-provider.process-output-limit[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.process-output-limit]`
 
 [.description]
 --
 The maximum size of the output that can be returned by the external process before an exception is raised.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++`
 endif::add-copy-button-to-env-var[]
 --|MemorySize  link:#memory-size-note-anchor[icon:question-circle[], title=More information about the MemorySize format]
 |`1024`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.command]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.command[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.command]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.process-provider.command]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.process-provider.command[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.command]`
 
 [.description]
 --
 The command that should be executed to retrieve credentials.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_COMMAND+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_COMMAND+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_COMMAND+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_COMMAND+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.process-provider.async-credential-update-enabled]`
-
-[.description]
---
-Whether the provider should fetch credentials asynchronously in the background.
-
-If this is true, threads are less likely to block when credentials are loaded, but additional resources are used to maintain the provider.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.credential-refresh-threshold]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.credential-refresh-threshold[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.process-provider.credential-refresh-threshold]`
-
-[.description]
---
-The amount of time between when the credentials expire and when the credentials should start to be refreshed.
-
-This allows the credentials to be refreshed ++*++before++*++ they are reported to expire.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++`
-endif::add-copy-button-to-env-var[]
---|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
-  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
-|`15S`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.process-output-limit]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.process-output-limit[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.process-provider.process-output-limit]`
-
-[.description]
---
-The maximum size of the output that can be returned by the external process before an exception is raised.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++`
-endif::add-copy-button-to-env-var[]
---|MemorySize  link:#memory-size-note-anchor[icon:question-circle[], title=More information about the MemorySize format]
-|`1024`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.command]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.command[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.process-provider.command]`
-
-[.description]
---
-The command that should be executed to retrieve credentials.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_COMMAND+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_COMMAND+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.async-credential-update-enabled]`
-
-[.description]
---
-Whether the provider should fetch credentials asynchronously in the background.
-
-If this is true, threads are less likely to block when credentials are loaded, but additional resources are used to maintain the provider.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.credential-refresh-threshold]`
-
-[.description]
---
-The amount of time between when the credentials expire and when the credentials should start to be refreshed.
-
-This allows the credentials to be refreshed ++*++before++*++ they are reported to expire.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++`
-endif::add-copy-button-to-env-var[]
---|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
-  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
-|`15S`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.process-provider.process-output-limit]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.process-provider.process-output-limit[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.process-output-limit]`
-
-[.description]
---
-The maximum size of the output that can be returned by the external process before an exception is raised.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++`
-endif::add-copy-button-to-env-var[]
---|MemorySize  link:#memory-size-note-anchor[icon:question-circle[], title=More information about the MemorySize format]
-|`1024`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.process-provider.command]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.process-provider.command[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.command]`
-
-[.description]
---
-The command that should be executed to retrieve credentials.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_COMMAND+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_COMMAND+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.process-provider.async-credential-update-enabled]`
-
-[.description]
---
-Whether the provider should fetch credentials asynchronously in the background.
-
-If this is true, threads are less likely to block when credentials are loaded, but additional resources are used to maintain the provider.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_ASYNC_CREDENTIAL_UPDATE_ENABLED+++`
-endif::add-copy-button-to-env-var[]
---|boolean 
-|`false`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.credential-refresh-threshold]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.credential-refresh-threshold[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.process-provider.credential-refresh-threshold]`
-
-[.description]
---
-The amount of time between when the credentials expire and when the credentials should start to be refreshed.
-
-This allows the credentials to be refreshed ++*++before++*++ they are reported to expire.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++`
-endif::add-copy-button-to-env-var[]
---|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
-  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
-|`15S`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.process-output-limit]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.process-output-limit[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.process-provider.process-output-limit]`
-
-[.description]
---
-The maximum size of the output that can be returned by the external process before an exception is raised.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++`
-endif::add-copy-button-to-env-var[]
---|MemorySize  link:#memory-size-note-anchor[icon:question-circle[], title=More information about the MemorySize format]
-|`1024`
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.command]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.process-provider.command[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.process-provider.command]`
-
-[.description]
---
-The command that should be executed to retrieve credentials.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_COMMAND+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_PROCESS_PROVIDER_COMMAND+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider-custom-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider-custom-credentials-provider-configuration[Custom credentials provider configuration]
+h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.custom-provider-custom-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.custom-provider-custom-credentials-provider-configuration[Custom credentials provider configuration]
 
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider.name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider.name[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider.name]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.custom-provider.name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.-backend-name-.aws.credentials.custom-provider.name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.custom-provider.name]`
 
 [.description]
 --
 The name of custom AwsCredentialsProvider bean.
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_CUSTOM_PROVIDER_NAME+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_CUSTOM_PROVIDER_NAME+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_CUSTOM_PROVIDER_NAME+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.custom-provider.name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.backends.-backend-name-.aws.credentials.custom-provider.name[quarkus.hibernate-search-orm.elasticsearch.backends."backend-name".aws.credentials.custom-provider.name]`
-
-[.description]
---
-The name of custom AwsCredentialsProvider bean.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_CUSTOM_PROVIDER_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_CUSTOM_PROVIDER_NAME+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.custom-provider.name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.aws.credentials.custom-provider.name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.custom-provider.name]`
-
-[.description]
---
-The name of custom AwsCredentialsProvider bean.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_CUSTOM_PROVIDER_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_AWS_CREDENTIALS_CUSTOM_PROVIDER_NAME+++`
-endif::add-copy-button-to-env-var[]
---|string 
-|
-
-
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.custom-provider.name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.-persistence-unit-name-.elasticsearch.backends.-backend-name-.aws.credentials.custom-provider.name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.backends."backend-name".aws.credentials.custom-provider.name]`
-
-[.description]
---
-The name of custom AwsCredentialsProvider bean.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_CUSTOM_PROVIDER_NAME+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH_BACKENDS__BACKEND_NAME__AWS_CREDENTIALS_CUSTOM_PROVIDER_NAME+++`
+Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM__PERSISTENCE_UNIT_NAME__ELASTICSEARCH__BACKEND_NAME__AWS_CREDENTIALS_CUSTOM_PROVIDER_NAME+++`
 endif::add-copy-button-to-env-var[]
 --|string 
 |

--- a/hibernate-search-orm-elasticsearch-aws/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/aws/runtime/HibernateSearchOrmElasticsearchAwsRuntimeConfig.java
+++ b/hibernate-search-orm-elasticsearch-aws/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/aws/runtime/HibernateSearchOrmElasticsearchAwsRuntimeConfig.java
@@ -2,25 +2,24 @@ package io.quarkus.hibernate.search.orm.elasticsearch.aws.runtime;
 
 import java.util.Map;
 
+import io.quarkus.hibernate.orm.runtime.PersistenceUnitUtil;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
 
-@ConfigRoot(name = "hibernate-search-orm", phase = ConfigPhase.RUN_TIME)
-public class HibernateSearchOrmElasticsearchAwsRuntimeConfig {
-
-    /**
-     * Configuration for the default persistence unit.
-     */
-    @ConfigItem(name = ConfigItem.PARENT)
-    public HibernateSearchOrmElasticsearchAwsRuntimeConfigPersistenceUnit defaultPersistenceUnit;
+@ConfigMapping(prefix = "quarkus.hibernate-search-orm")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface HibernateSearchOrmElasticsearchAwsRuntimeConfig {
 
     /**
-     * Configuration for additional named persistence units.
+     * Configuration for persistence units.
      */
+    @WithParentName
+    @WithUnnamedKey(PersistenceUnitUtil.DEFAULT_PERSISTENCE_UNIT_NAME)
     @ConfigDocMapKey("persistence-unit-name")
-    @ConfigItem(name = ConfigItem.PARENT)
-    public Map<String, HibernateSearchOrmElasticsearchAwsRuntimeConfigPersistenceUnit> persistenceUnits;
+    Map<String, HibernateSearchOrmElasticsearchAwsRuntimeConfigPersistenceUnit> persistenceUnits();
 
 }

--- a/hibernate-search-orm-elasticsearch-aws/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/aws/runtime/HibernateSearchOrmElasticsearchAwsRuntimeConfigPersistenceUnit.java
+++ b/hibernate-search-orm-elasticsearch-aws/runtime/src/main/java/io/quarkus/hibernate/search/orm/elasticsearch/aws/runtime/HibernateSearchOrmElasticsearchAwsRuntimeConfigPersistenceUnit.java
@@ -6,54 +6,38 @@ import java.util.Optional;
 import io.quarkus.amazon.common.runtime.AwsCredentialsProviderConfig;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
 import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.smallrye.config.WithName;
+import io.smallrye.config.WithUnnamedKey;
 import software.amazon.awssdk.regions.Region;
 
 @ConfigGroup
-public class HibernateSearchOrmElasticsearchAwsRuntimeConfigPersistenceUnit {
+public interface HibernateSearchOrmElasticsearchAwsRuntimeConfigPersistenceUnit {
 
     /**
-     * Default backend
+     * Configuration for backends.
      */
-    @ConfigItem(name = "elasticsearch")
-    ElasticsearchBackendRuntimeConfig defaultBackend;
-
-    /**
-     * Named backends
-     */
-    @ConfigItem(name = "elasticsearch")
-    public ElasticsearchNamedBackendsRuntimeConfig namedBackends;
+    @WithName("elasticsearch")
+    @WithUnnamedKey // The default backend has the null key
+    @ConfigDocMapKey("backend-name")
+    Map<String, ElasticsearchBackendRuntimeConfig> backends();
 
     @ConfigGroup
-    public static class ElasticsearchNamedBackendsRuntimeConfig {
-
-        /**
-         * Named backends
-         */
-        @ConfigDocMapKey("backend-name")
-        public Map<String, ElasticsearchBackendRuntimeConfig> backends;
-
-    }
-
-    @ConfigGroup
-    public static class ElasticsearchBackendRuntimeConfig {
+    interface ElasticsearchBackendRuntimeConfig {
 
         /**
          * AWS services configurations
          */
-        @ConfigItem
-        ElasticsearchBackendAwsConfig aws;
+        ElasticsearchBackendAwsConfig aws();
 
     }
 
     @ConfigGroup
-    public static class ElasticsearchBackendAwsConfig {
+    interface ElasticsearchBackendAwsConfig {
 
         /**
-         * Whether requests should be signed using the AWS credentials.
+         * Configuration for signing.
          */
-        @ConfigItem(name = "signing.enabled")
-        boolean signingEnabled;
+        ElasticsearchBackendAwsSigningConfig signing();
 
         // @formatter:off
         /**
@@ -66,14 +50,22 @@ public class HibernateSearchOrmElasticsearchAwsRuntimeConfigPersistenceUnit {
          * @asciidoclet
          */
         // @formatter:on
-        @ConfigItem
-        Optional<Region> region;
+        Optional<Region> region();
 
         /**
          * Defines the credentials provider.
          */
-        @ConfigItem
-        AwsCredentialsProviderConfig credentials;
+        AwsCredentialsProviderConfig credentials();
+
+    }
+
+    @ConfigGroup
+    interface ElasticsearchBackendAwsSigningConfig {
+
+        /**
+         * Whether requests should be signed using the AWS credentials.
+         */
+        boolean enabled();
 
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>3.2.2.Final</quarkus.version>
         <maven-processor-plugin.version>4.5</maven-processor-plugin.version>
-        <quarkus-amazon-services.version>2.4.0</quarkus-amazon-services.version>
+        <quarkus-amazon-services.version>2.4.2</quarkus-amazon-services.version>
         <!-- Unfortunately we cannot use a BOM for Maven plugin dependencies -->
         <awssdk.version.for-annotation-processor>2.20.98</awssdk.version.for-annotation-processor>
         <assertj.version>3.24.2</assertj.version>


### PR DESCRIPTION
Necessary to catch up with quarkus-amazon-services, which migrated to `@ConfigMapping`. The build just fails otherwise because we'd be mixing `@ConfigMapping` from quarkus-amazon-servivces with old-style configuration.

The generated documentation for configuration properties is not great at the moment (it only mentions configuration for named PUs/backends) because Quarkus 3.2 doesn't include https://github.com/quarkusio/quarkus/pull/34514 , but it's simpler that way. Let's wait for a backport in 3.2 or for 3.3 to get correct documentation.