### PR TITLE
Release 2.0.5

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 2.0.4
+  current-version: 2.0.5
   next-version: 999-SNAPSHOT


### PR DESCRIPTION
Because the 2.0.4 release seems to have pushed... half of the artifacts? I don't know, but something went wrong.