### PR TITLE
Take advantage of the BOM to process amazon-services-related configuration classes

### DIFF
--- a/hibernate-search-orm-elasticsearch-aws/runtime/pom.xml
+++ b/hibernate-search-orm-elasticsearch-aws/runtime/pom.xml
@@ -36,6 +36,37 @@
             <artifactId>graal-sdk</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Copy some of quarkus-amazon-common's optional dependencies,
+             just to take into account AwsCredentialsProviderConfig when generating configuration
+             and its documentation.
+             Make sure to mark these dependencies as optional here, too,
+             so that they don't affect applications but only the build. -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-aws-sdk-2.2</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>
@@ -46,10 +77,10 @@
                 <version>${maven-processor-plugin.version}</version>
                 <executions>
                     <!-- Run annotation processors on quarkus-amazon-common,
-                         just to generate the documentation for AwsCredentialsProviderConfig,
-                         so we can embed it in our own documentation. -->
+                         just to generate the necessary metadata/documentation for AwsCredentialsProviderConfig,
+                         so that it will get embedded in our own documentation. -->
                     <execution>
-                        <id>process</id>
+                        <id>process-quarkus-amazon-common</id>
                         <goals>
                             <goal>process</goal>
                         </goals>
@@ -66,39 +97,6 @@
                         <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-extension-processor</artifactId>
                         <version>${quarkus.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>io.quarkiverse.amazonservices</groupId>
-                        <artifactId>quarkus-amazon-common</artifactId>
-                        <version>${quarkus-amazon-services.version}</version>
-                    </dependency>
-                    <!-- Optional dependencies of quarkus-amazon-common
-                         These are necessary for annotation processing. -->
-                    <dependency>
-                        <groupId>software.amazon.awssdk</groupId>
-                        <artifactId>netty-nio-client</artifactId>
-                        <version>${awssdk.version.for-annotation-processor}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>software.amazon.awssdk</groupId>
-                        <artifactId>url-connection-client</artifactId>
-                        <version>${awssdk.version.for-annotation-processor}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>software.amazon.awssdk</groupId>
-                        <artifactId>apache-client</artifactId>
-                        <version>${awssdk.version.for-annotation-processor}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>software.amazon.awssdk</groupId>
-                        <artifactId>aws-crt-client</artifactId>
-                        <version>${awssdk.version.for-annotation-processor}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>io.opentelemetry.instrumentation</groupId>
-                        <artifactId>opentelemetry-aws-sdk-2.2</artifactId>
-                        <optional>true</optional>
-                        <version>${awsotel.version.for-annotation-processor}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,32 @@
         </plugins>
     </build>
     <profiles>
+        <!-- The profiles `skippingAllTests` and `skippingIntegrationTests` are currently duplicates,
+            as one can't trigger the profile activation on either/or property -->
+        <profile>
+            <id>skippingAllTests</id>
+            <activation>
+                <property>
+                    <name>skipTests</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- This is to avoid starting containers for each module needing integration test -->
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>skippingIntegrationTests</id>
+            <activation>
+                <property>
+                    <name>skipITs</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- This is to avoid starting containers for each module needing integration test -->
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
         <!--
                  WARNING: this MUST be the very last profile,
                  so that the "release" module is the very last module,

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
       <tag>HEAD</tag>
   </scm>
     <properties>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>3.12.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,6 @@
         <quarkus.version>3.6.4</quarkus.version>
         <maven-processor-plugin.version>4.5</maven-processor-plugin.version>
         <quarkus-amazon-services.version>2.9.0</quarkus-amazon-services.version>
-        <!-- Unfortunately we cannot use a BOM for Maven plugin dependencies -->
-        <awssdk.version.for-annotation-processor>2.21.17</awssdk.version.for-annotation-processor>
-        <awsotel.version.for-annotation-processor>1.32.0-alpha</awsotel.version.for-annotation-processor>
         <assertj.version>3.25.1</assertj.version>
         <wiremock.version>2.27.2</wiremock.version>
         <wiremock-maven-plugin.version>7.3.0</wiremock-maven-plugin.version>


### PR DESCRIPTION
So that we don't have to specify the version of transitive dependencies manually.