### PR TITLE
Update tests for compatibility with Hibernate Search 7.2

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:quarkus-version: 3.11.1
+:quarkus-version: 3.13.0
 :quarkus-hibernate-search-extras-version: 4.1.0
 
 :quarkus-org-url: https://github.com/quarkusio

--- a/docs/modules/ROOT/pages/includes/quarkus-hibernate-search-orm-elasticsearch-aws.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-hibernate-search-orm-elasticsearch-aws.adoc
@@ -10,13 +10,13 @@ h|[[quarkus-hibernate-search-orm-elasticsearch-aws_configuration]]link:#quarkus-
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled[quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-signing-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-signing-enabled[quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.signing.enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-signing-enabled[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.signing.enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.signing.enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-signing-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.signing.enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.signing.enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.signing.enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-signing-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.signing.enabled]`
 
 
 [.description]
@@ -33,13 +33,13 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.region]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.region[quarkus.hibernate-search-orm.elasticsearch.aws.region]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-region]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-region[quarkus.hibernate-search-orm.elasticsearch.aws.region]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.region[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.region]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-region[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.region]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.region[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.region]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-region[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.region]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.region[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.region]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-region[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.region]`
 
 
 [.description]
@@ -60,13 +60,13 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-type]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-type[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.type]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-type[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.type]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.type]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-type[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.type]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.type[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.type]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-type[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.type]`
 
 
 [.description]
@@ -107,18 +107,18 @@ endif::add-copy-button-to-env-var[]
 |`default`
 
 
-h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider-default-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider-default-credentials-provider-configuration[Default credentials provider configuration]
+h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-default-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-default-credentials-provider-configuration[Default credentials provider configuration]
 
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.default-provider.async-credential-update-enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.default-provider.async-credential-update-enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.default-provider.async-credential-update-enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.default-provider.async-credential-update-enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.default-provider.async-credential-update-enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.default-provider.async-credential-update-enabled]`
 
 
 [.description]
@@ -137,13 +137,13 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-reuse-last-provider-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-reuse-last-provider-enabled[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.default-provider.reuse-last-provider-enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-reuse-last-provider-enabled[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.default-provider.reuse-last-provider-enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.default-provider.reuse-last-provider-enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-reuse-last-provider-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.default-provider.reuse-last-provider-enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-default-provider-reuse-last-provider-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.default-provider.reuse-last-provider-enabled]`
 
 
 [.description]
@@ -162,18 +162,18 @@ endif::add-copy-button-to-env-var[]
 |`true`
 
 
-h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider-static-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider-static-credentials-provider-configuration[Static credentials provider configuration]
+h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-static-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-static-credentials-provider-configuration[Static credentials provider configuration]
 
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-access-key-id]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-access-key-id[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.static-provider.access-key-id]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-access-key-id[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.static-provider.access-key-id]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.static-provider.access-key-id]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-access-key-id[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.static-provider.access-key-id]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.access-key-id[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.static-provider.access-key-id]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-access-key-id[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.static-provider.access-key-id]`
 
 
 [.description]
@@ -190,13 +190,13 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-secret-access-key]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-secret-access-key[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.static-provider.secret-access-key]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-secret-access-key[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.static-provider.secret-access-key]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.static-provider.secret-access-key]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-secret-access-key[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.static-provider.secret-access-key]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.secret-access-key[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.static-provider.secret-access-key]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-secret-access-key[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.static-provider.secret-access-key]`
 
 
 [.description]
@@ -213,13 +213,13 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.session-token]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.session-token[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.session-token]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-session-token]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-session-token[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.session-token]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.session-token[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.static-provider.session-token]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-session-token[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.static-provider.session-token]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.session-token[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.static-provider.session-token]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-session-token[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.static-provider.session-token]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.static-provider.session-token[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.static-provider.session-token]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-static-provider-session-token[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.static-provider.session-token]`
 
 
 [.description]
@@ -236,18 +236,18 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider-aws-profile-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider-aws-profile-credentials-provider-configuration[AWS Profile credentials provider configuration]
+h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-profile-provider-aws-profile-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-profile-provider-aws-profile-credentials-provider-configuration[AWS Profile credentials provider configuration]
 
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider.profile-name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider.profile-name[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider.profile-name]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-profile-provider-profile-name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-profile-provider-profile-name[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider.profile-name]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider.profile-name[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.profile-provider.profile-name]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-profile-provider-profile-name[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.profile-provider.profile-name]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider.profile-name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.profile-provider.profile-name]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-profile-provider-profile-name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.profile-provider.profile-name]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.profile-provider.profile-name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.profile-provider.profile-name]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-profile-provider-profile-name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.profile-provider.profile-name]`
 
 
 [.description]
@@ -266,18 +266,18 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider-process-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider-process-credentials-provider-configuration[Process credentials provider configuration]
+h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-process-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-process-credentials-provider-configuration[Process credentials provider configuration]
 
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-async-credential-update-enabled]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.process-provider.async-credential-update-enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-async-credential-update-enabled[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.process-provider.async-credential-update-enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.async-credential-update-enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.async-credential-update-enabled]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.async-credential-update-enabled]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-async-credential-update-enabled[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.async-credential-update-enabled]`
 
 
 [.description]
@@ -296,13 +296,13 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-credential-refresh-threshold]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-credential-refresh-threshold[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.process-provider.credential-refresh-threshold]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-credential-refresh-threshold[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.process-provider.credential-refresh-threshold]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.credential-refresh-threshold]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-credential-refresh-threshold[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.credential-refresh-threshold]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.credential-refresh-threshold[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.credential-refresh-threshold]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-credential-refresh-threshold[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.credential-refresh-threshold]`
 
 
 [.description]
@@ -318,17 +318,17 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_CREDENTIAL_REFRESH_THRESHOLD+++`
 endif::add-copy-button-to-env-var[]
 --|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
-  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[], title=More information about the Duration format]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
 |`15S`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.process-output-limit]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.process-output-limit[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.process-output-limit]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-process-output-limit]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-process-output-limit[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.process-output-limit]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.process-output-limit[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.process-provider.process-output-limit]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-process-output-limit[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.process-provider.process-output-limit]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.process-output-limit[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.process-output-limit]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-process-output-limit[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.process-output-limit]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.process-output-limit[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.process-output-limit]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-process-output-limit[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.process-output-limit]`
 
 
 [.description]
@@ -341,17 +341,17 @@ endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_HIBERNATE_SEARCH_ORM_ELASTICSEARCH_AWS_CREDENTIALS_PROCESS_PROVIDER_PROCESS_OUTPUT_LIMIT+++`
 endif::add-copy-button-to-env-var[]
---|MemorySize  link:#memory-size-note-anchor[icon:question-circle[], title=More information about the MemorySize format]
+--|MemorySize  link:#memory-size-note-anchor[icon:question-circle[title=More information about the MemorySize format]]
 |`1024`
 
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.command]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.command[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.command]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-command]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-command[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.command]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.command[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.process-provider.command]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-command[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.process-provider.command]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.command[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.command]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-command[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.process-provider.command]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.process-provider.command[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.command]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-process-provider-command[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.process-provider.command]`
 
 
 [.description]
@@ -368,18 +368,18 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider-custom-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider-custom-credentials-provider-configuration[Custom credentials provider configuration]
+h|[[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-custom-provider-custom-credentials-provider-configuration]]link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-custom-provider-custom-credentials-provider-configuration[Custom credentials provider configuration]
 
 h|Type
 h|Default
 
-a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider.name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider.name[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider.name]`
+a| [[quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-custom-provider-name]]`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-custom-provider-name[quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider.name]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider.name[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.custom-provider.name]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-custom-provider-name[quarkus.hibernate-search-orm.elasticsearch."backend-name".aws.credentials.custom-provider.name]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider.name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.custom-provider.name]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-custom-provider-name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch."backend-name".aws.credentials.custom-provider.name]`
 
-`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus.hibernate-search-orm.elasticsearch.aws.credentials.custom-provider.name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.custom-provider.name]`
+`link:#quarkus-hibernate-search-orm-elasticsearch-aws_quarkus-hibernate-search-orm-elasticsearch-aws-credentials-custom-provider-name[quarkus.hibernate-search-orm."persistence-unit-name".elasticsearch.aws.credentials.custom-provider.name]`
 
 
 [.description]
@@ -402,7 +402,7 @@ ifndef::no-duration-note[]
 .About the Duration format
 ====
 To write duration values, use the standard `java.time.Duration` format.
-See the link:https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)[Duration#parse() javadoc] for more information.
+See the link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)[Duration#parse() Java API documentation] for more information.
 
 You can also use a simplified format, starting with a number:
 

--- a/integration-tests/hibernate-search-orm-elasticsearch-aws/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/aws/HibernateSearchAwsTest.java
+++ b/integration-tests/hibernate-search-orm-elasticsearch-aws/src/test/java/io/quarkus/it/hibernate/search/elasticsearch/aws/HibernateSearchAwsTest.java
@@ -53,7 +53,8 @@ public class HibernateSearchAwsTest {
                 .allSatisfy(request -> {
                     assertHeader(request, "Authorization")
                             .matches("AWS4-HMAC-SHA256 Credential=[a-zA-Z0-9]+/[0-9]+/us-east-1/es/aws4_request,"
-                                    + " SignedHeaders=host;x-amz-date, Signature=[a-f0-9]+");
+                                    // x-amz-content-sha256 only gets signed starting with Hibernate Search 7.2
+                                    + " SignedHeaders=host;(x-amz-content-sha256;)?x-amz-date, Signature=[a-f0-9]+");
                     assertHeader(request, "X-Amz-Date")
                             .matches("[0-9]{8}T[0-9]{6}Z");
                 });


### PR DESCRIPTION
So that tests pass after the upgrade coming in Quarkus 3.14.

See https://github.com/quarkiverse/quarkiverse/issues/57#issuecomment-2283145329