### PR TITLE
Backport to 4.x: Remove hack around documentation of AWS credentials provider config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,6 @@ updates:
           - "io.quarkiverse:*"
           - "io.quarkiverse.*:*"
     ignore:
-      # We require JDK 11, so we don't need "-jdk8"
-      - dependency-name: "org.bsc.maven:maven-processor-plugin"
-        # Apparently patterns using wildcards are not supported here. Hopefully this will last until they drop these silly -jdk8 packages.
-        versions: ["5.0-jdk8", "5.1-jdk8", "5.2-jdk8", "5.3-jdk8", "5.4-jdk8", "5.5-jdk8", "5.6-jdk8", "5.7-jdk8", "5.8-jdk8", "5.9-jdk8"]
       # Releases too often, it's annoying
       - dependency-name: "org.assertj:*"
         update-types: ["version-update:semver-patch"]

--- a/hibernate-search-orm-elasticsearch-aws/runtime/pom.xml
+++ b/hibernate-search-orm-elasticsearch-aws/runtime/pom.xml
@@ -72,35 +72,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.bsc.maven</groupId>
-                <artifactId>maven-processor-plugin</artifactId>
-                <version>${maven-processor-plugin.version}</version>
-                <executions>
-                    <!-- Run annotation processors on quarkus-amazon-common,
-                         just to generate the necessary metadata/documentation for AwsCredentialsProviderConfig,
-                         so that it will get embedded in our own documentation. -->
-                    <execution>
-                        <id>process-quarkus-amazon-common</id>
-                        <goals>
-                            <goal>process</goal>
-                        </goals>
-                        <phase>process-sources</phase>
-                        <configuration>
-                            <addCompileSourceRoots>false</addCompileSourceRoots>
-                            <includes>io/quarkus/amazon/**/*.java</includes>
-                            <processSourceArtifacts>io.quarkiverse.amazonservices:quarkus-amazon-common:${quarkus-amazon-services.version}</processSourceArtifacts>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>io.quarkus</groupId>
-                        <artifactId>quarkus-extension-processor</artifactId>
-                        <version>${quarkus.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>3.15.1</quarkus.version>
-        <maven-processor-plugin.version>5.1</maven-processor-plugin.version>
         <quarkus-amazon-services.version>2.18.1</quarkus-amazon-services.version>
         <assertj.version>3.26.0</assertj.version>
         <wiremock.version>2.27.2</wiremock.version>


### PR DESCRIPTION
This is no longer necessary with the new extension annotation processor in Quarkus 3.14.